### PR TITLE
Enable Evil's C-u to scroll page up

### DIFF
--- a/config.org
+++ b/config.org
@@ -348,6 +348,7 @@ Vim keybindings in Emacs. Please note that Witchmacs has NO other evil-mode comp
     :ensure t
     :init
     (setq evil-want-keybinding nil)
+    (setq evil-want-C-u-scroll t)
     :config
     (evil-mode 1))
 


### PR DESCRIPTION
Sets `evil-want-C-u-scroll` to `t`. It's the counterpart to vi's `C-d` to scroll page up. Coming from Vim I found it irritating that `C-u` didn't do page up just to preserve Emacs' `C-u' commands, whose functions are provided by Evil anyways, so what's the point? (Things like repeating commands or killing a line backwards).